### PR TITLE
feat: promote alcohol carbon to v1.11.* on pikachu

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -42,5 +42,5 @@ apps:
       chart: alcohol-carbon
       landscapes:
         pichu: v1.*.*
-        pikachu: v1.10.*
+        pikachu: v1.11.*
         raichu: v1.10.0


### PR DESCRIPTION
Promotes **zinc account-deletion backend** to **pikachu (staging)**.

## Change
`values.entei.opal-ruby.yaml` → `alcohol.carbon.landscapes.pikachu`: `v1.10.*` → **`v1.11.*`**

The ApplicationSet currently pins pikachu to the v1.10 minor; carbon's latest is **v1.11.0** (= zinc root-chart **v1.20.0**), so pikachu is behind. Bumping to `v1.11.*` lets ArgoCD sync carbon v1.11.0 to pikachu.

## What it brings to staging
- `DELETE /api/v1.0/User/Me` self-delete (Logto + Postgres hard-delete, ledger anonymize-retain)
- `BlockAccountDeletionOnDebt` debt gate (409)
- Best-effort Airwallex consent revocation

## Scope
- ✅ pikachu only (keeps the `.*` minor-wildcard convention used for staging)
- ⛔ raichu unchanged (`v1.10.0`, production gated)
- Already verified end-to-end on pichu (auto-tracks `v1.*.*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version pattern from v1.10.* to v1.11.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->