### PR TITLE
feat: promote alcohol carbon to v1.11.0 on raichu (production)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -43,4 +43,4 @@ apps:
       landscapes:
         pichu: v1.*.*
         pikachu: v1.11.*
-        raichu: v1.10.0
+        raichu: v1.11.0


### PR DESCRIPTION
Promotes **zinc account-deletion backend** to **raichu (PRODUCTION)**.

## Change
`values.entei.opal-ruby.yaml` → `alcohol.carbon.landscapes.raichu`: `v1.10.0` → **`v1.11.0`** (exact pin retained for prod).

ArgoCD will sync carbon **v1.11.0** (= zinc root-chart **v1.20.0**) to raichu, including the auto DB-migration sync-hook.

## What goes to production
- `DELETE /api/v1.0/User/Me` self-delete (Logto + Postgres hard-delete; donation/charge ledger anonymize-retain)
- `BlockAccountDeletionOnDebt` debt gate (409)
- Best-effort Airwallex consent revocation

## Verified before prod
- ✅ pichu (auto-tracks `v1.*.*`) — full real-user e2e (debt-block fired live)
- ✅ pikachu (`v1.11.*`) — `DELETE /Me` → 401, page 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)