### PR TITLE
action: zinc 1.34.0 + helium 1.19.1 to pikachu (hold raichu)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -11,8 +11,8 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.zinc
       chart: root-chart
       landscapes:
-        pichu: ^1.33.2
-        pikachu: ~1.33.2
+        pichu: ^1.34.0
+        pikachu: ~1.34.0
         raichu: 1.33.2
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
@@ -25,8 +25,8 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.helium
       chart: root-chart
       landscapes:
-        pichu: ^1.17.0
-        pikachu: ~1.17.0
+        pichu: ^1.19.1
+        pikachu: ~1.19.1
         raichu: 1.17.0
   sulfone:
     zinc:


### PR DESCRIPTION
## Staged rollout — pikachu (staging) first, raichu (production) later

Promotes the duplicate-passport recovery backend to **pichu (dev)** and **pikachu (staging)**, and **holds raichu (production)** at the current pins for a follow-up PR.

| Service | pichu (dev) | pikachu (staging) | raichu (prod) |
|---|---|---|---|
| **helium** | `^1.17.0` → `^1.19.1` | `~1.17.0` → `~1.19.1` | **held at 1.17.0** |
| **zinc** | `^1.33.2` → `^1.34.0` | `~1.33.2` → `~1.34.0` | **held at 1.33.2** |

(pichu is a caret floor that already resolves to the latest; the bump keeps the floor honest. The real staging promotion is pikachu.)

## What ships to pikachu
- **helium 1.19.1** — removes the `reverter` cron (root-cause fix). Also pulls in the intervening 1.18.x/1.19.0 releases.
- **zinc 1.34.0** — `Recovering`/`Duplicate`/`RequireManualIntervention` state machine, guarded transitions, `revert` endpoint removed (exactly the 1.33.2→1.34.0 delta).

## Sequencing
1. This PR → **pikachu** gets helium + zinc.
2. A follow-up PR bumps **raichu** once pikachu looks healthy.
3. **tin** (recoverer) stays at 1.43.0 — deployed separately and exercised via the manual `recover` CLI before its cron is enabled.

⚠️ helium jumps 1.17→1.19.1 (two minors), so more than the reverter removal ships. Confirm the intervening releases are fine before merging.

https://claude.ai/code/session_01Xyb9Y7aiWqGwGbtXRAL3ES