### PR TITLE
action: zinc 1.34.0 + helium 1.19.1 to raichu (prod); hold tin

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -13,7 +13,7 @@ apps:
       landscapes:
         pichu: ^1.34.0
         pikachu: ~1.34.0
-        raichu: 1.33.2
+        raichu: 1.34.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart
@@ -27,7 +27,7 @@ apps:
       landscapes:
         pichu: ^1.19.1
         pikachu: ~1.19.1
-        raichu: 1.17.0
+        raichu: 1.19.1
   sulfone:
     zinc:
       repoURL: ghcr.io/atomicloud/sulfone.zinc


### PR DESCRIPTION
## Production (raichu) deploy of the recovery backend

Bumps the **raichu** pins for zinc and helium. pichu/pikachu already on these versions (from #10); tin **held** at 1.43.0.

| Service | raichu: from → to |
|---|---|
| **zinc** | 1.33.2 → **1.34.0** — recovery state machine, guarded transitions, `revert` removed |
| **helium** | 1.17.0 → **1.19.1** — reverter cron removed (+ intervening 1.18.x/1.19.0) |
| tin | **held at 1.43.0** — recoverer cron NOT enabled in prod yet |

### DB
No migration needed for zinc — the new statuses (6/7/8) and `BookingDuplicate` (12) are new enum values in existing `smallint` columns; `PassportNumber` is a query filter on an existing column. raichu `AutoMigrate: false` anyway.

### Why tin is held
tin's recoverer autonomously moves money (refunds/re-buys) and has never run against real KTMB/zinc/redis. It'll be deployed + exercised via the manual `recover` CLI before its hourly cron is enabled — a separate PR.

https://claude.ai/code/session_01Xyb9Y7aiWqGwGbtXRAL3ES