### PR TITLE
action: tin to 1.44.0 (duplicate-passport recoverer)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -18,9 +18,9 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart
       landscapes:
-        pichu: ^1.43.0
-        pikachu: ~1.43.0
-        raichu: 1.43.0
+        pichu: ^1.44.0
+        pikachu: ~1.44.0
+        raichu: 1.44.0
     helium:
       repoURL: ghcr.io/atomicloud/nitroso.helium
       chart: root-chart


### PR DESCRIPTION
Ships **tin v1.44.0** — the duplicate-passport recovery pipeline — to all nitroso landscapes (pichu `^`, pikachu `~`, raichu prod exact).

## What lands
- **recoverer** module: hourly `sweep` (zinc reconciliation) + 15m `drain` (recover queue), single-replica Deployment.
- **crash-safe buyer**: on a duplicate-passport conflict it parks the booking in `Recovering` and pushes to the recover queue instead of crash-looping (this is what fixes the tin-buyer 360-restart loop in prod).

## Dependencies (already live)
- zinc **1.34.0** — recovery state machine (`Recovering`/`Duplicate`/`RequireManualIntervention`), `revert` removed.
- helium **1.19.1** — reverter cron removed (root cause of ledger corruption).

## Safety
- v1.44.0 went through 4 floop rounds + 7 kloop iterations focused on money-safety (no double-collect, no wrongful refund, inconclusive scans retry not refund).
- On first deploy the recover queue is empty and no bookings are in `Recovering`, so the recoverer is a no-op until the new buyer parks real work.

https://claude.ai/code/session_01Xyb9Y7aiWqGwGbtXRAL3ES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bundled app version pins to a newer release across related components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->