### PR TITLE
action: tin to 1.44.1 (duplicate-passport conflict-pattern fix)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -20,7 +20,7 @@ apps:
       landscapes:
         pichu: ^1.44.0
         pikachu: ~1.44.0
-        raichu: 1.44.0
+        raichu: 1.44.1
     helium:
       repoURL: ghcr.io/atomicloud/nitroso.helium
       chart: root-chart


### PR DESCRIPTION
Bumps **raichu (prod) tin 1.44.0 → 1.44.1**.

**What v1.44.1 fixes:** the buyer's `conflictPatterns` only had `'duplicate passport'`, which does not match KTMB's real SetPassenger message `"Duplicated passport number for onward trip : <passport>"` (extra **d** in Duplicate**d**). Result: every duplicate conflict since the 1.44.0 deploy fell through to the generic-error path and stranded the booking in `Buying` — never parked for recovery. v1.44.1 adds `'duplicated passport'` (in both the local and chart-effective config), with tests + a regression guard.

Reviewed via floop (2 rounds, all pass) before merge.

pichu (`^`) and pikachu (`~`) auto-resolve to 1.44.1; only raichu's exact pin needs this bump.

https://claude.ai/code/session_01Xyb9Y7aiWqGwGbtXRAL3ES