### PR TITLE
action: zinc to 1.35.0 (Duplicate + ManualIntervention emails)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -11,9 +11,9 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.zinc
       chart: root-chart
       landscapes:
-        pichu: ^1.34.0
-        pikachu: ~1.34.0
-        raichu: 1.34.0
+        pichu: ^1.35.0
+        pikachu: ~1.35.0
+        raichu: 1.35.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart


### PR DESCRIPTION
Bumps **zinc 1.34.0 → 1.35.0** across all nitroso landscapes.

**v1.35.0** adds dedicated customer emails for two recovery transitions that previously left users under-informed:
- **Duplicate** → "we found a duplicate ticket, refunded you in full — contact us if this is a mistake" (was the generic cancelled email).
- **RequireManualIntervention** → "we hit a snag, your money is safe, we're reviewing it — contact us" (was no email at all).

Minor bump: pikachu (`~`) and raichu (exact pin) both require the bump; pichu (`^`) floor raised for consistency. No DB migration — the change is code-only.

Reviewed via floop (all lenses PASS) and merged after a green CI (both Docker builds + CodeRabbit).

https://claude.ai/code/session_01Xyb9Y7aiWqGwGbtXRAL3ES