### PR TITLE
action: zinc to 1.36.0 (atomic revert + recoverer 403 fix)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -11,9 +11,9 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.zinc
       chart: root-chart
       landscapes:
-        pichu: ^1.35.0
-        pikachu: ~1.35.0
-        raichu: 1.35.0
+        pichu: ^1.36.0
+        pikachu: ~1.36.0
+        raichu: 1.36.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart


### PR DESCRIPTION
Bumps **zinc 1.35.0 → 1.36.0**.

v1.36.0:
- **Atomic `Revert(id)`** (`Buying → Pending`, guarded Buying-only + uncaptured) + `POST /booking/revert/{id}` — recycles bookings stuck after transient failures (e.g. KTMB wallet insufficient).
- **403 fix**: recoverer (`tin`) can now `GET /booking/{id}` (was admin-only → every recovery failed).

Minor bump: pikachu (`~`) + raichu (exact) need it; pichu (`^`) floor raised. No DB migration.

https://claude.ai/code/session_01Xyb9Y7aiWqGwGbtXRAL3ES