### PR TITLE
action: tin to 1.45.0 (buyer auto-revert on wallet-insufficient)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -18,9 +18,9 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart
       landscapes:
-        pichu: ^1.44.0
-        pikachu: ~1.44.0
-        raichu: 1.44.1
+        pichu: ^1.45.0
+        pikachu: ~1.45.0
+        raichu: 1.45.0
     helium:
       repoURL: ghcr.io/atomicloud/nitroso.helium
       chart: root-chart


### PR DESCRIPTION
Bumps **tin 1.44.1 → 1.45.0**. The buyer now auto-reverts `Buying → Pending` (via zinc's atomic Revert) when Pay fails with 'wallet balance is insufficient', so bookings retry instead of stranding. Depends on zinc 1.36 (deployed).

https://claude.ai/code/session_01Xyb9Y7aiWqGwGbtXRAL3ES