### PR TITLE
action: zinc to 1.37.0 (RequireManualIntervention admin actions)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -11,9 +11,9 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.zinc
       chart: root-chart
       landscapes:
-        pichu: ^1.36.0
-        pikachu: ~1.36.0
-        raichu: 1.36.0
+        pichu: ^1.37.0
+        pikachu: ~1.37.0
+        raichu: 1.37.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart


### PR DESCRIPTION
Bumps **zinc 1.36.0 → 1.37.0**: admin resolution actions for RequireManualIntervention (Cancel/Revert/Complete guards extended + new complete-no-collect bypass endpoint). No migration.

https://claude.ai/code/session_01Xyb9Y7aiWqGwGbtXRAL3ES