### PR TITLE
action: tin to 1.46.0 (recoverer marks Duplicate when ticket not on our KTMB account)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -18,9 +18,9 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart
       landscapes:
-        pichu: ^1.45.0
-        pikachu: ~1.45.0
-        raichu: 1.45.0
+        pichu: ^1.46.0
+        pikachu: ~1.46.0
+        raichu: 1.46.0
     helium:
       repoURL: ghcr.io/atomicloud/nitroso.helium
       chart: root-chart


### PR DESCRIPTION
Deploys **nitroso.tin v1.46.0** across pichu / pikachu / raichu.

## Change
Recoverer: when the KTMB `UpcomingShuttleList` scan finds the passenger's ticket is **definitively not on our account**, mark the booking **Duplicate (refund)** directly — removing the re-buy probe that dead-ended at `RequireManualIntervention` on sold-out trains.

Money-safe: only a *definitive* not-found refunds; inconclusive scans still retry. Found-path double-charge gate unchanged. Recoverer never re-buys now.

Source PR: AtomiCloud/nitroso.tin#34 → released v1.46.0.

## Pins
```
pichu:   ^1.45.0 → ^1.46.0
pikachu: ~1.45.0 → ~1.46.0
raichu:  1.45.0  → 1.46.0
```

https://claude.ai/code/session_01Xyb9Y7aiWqGwGbtXRAL3ES