### PR TITLE
action: deploy withdrawal-fee rollout to pichu and pikachu

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -11,22 +11,22 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.zinc
       chart: root-chart
       landscapes:
-        pichu: ^1.37.0
-        pikachu: ~1.37.0
+        pichu: ^1.38.0
+        pikachu: ~1.38.0
         raichu: 1.37.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart
       landscapes:
-        pichu: ^1.46.0
-        pikachu: ~1.46.0
+        pichu: ^1.47.0
+        pikachu: ~1.47.0
         raichu: 1.46.0
     helium:
       repoURL: ghcr.io/atomicloud/nitroso.helium
       chart: root-chart
       landscapes:
-        pichu: ^1.19.1
-        pikachu: ~1.19.1
+        pichu: ^1.20.0
+        pikachu: ~1.20.0
         raichu: 1.19.1
   sulfone:
     zinc:


### PR DESCRIPTION
Bumps pichu/pikachu pins for the withdrawal-fee + automated-payout rollout: zinc 1.38.0 (AtomiCloud/nitroso.zinc#23), tin 1.47.0 (AtomiCloud/nitroso.tin#35, #36), helium 1.20.0 (AtomiCloud/nitroso.helium#32). raichu intentionally unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several app layer package version pins to newer releases.
  * Aligned component versions across multiple layers for `pichu` and `pikachu`, while keeping related versions unchanged where needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->