### PR TITLE
action: deploy reconciliation round to pichu and pikachu

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -11,15 +11,15 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.zinc
       chart: root-chart
       landscapes:
-        pichu: ^1.38.0
-        pikachu: ~1.38.0
+        pichu: ^1.39.0
+        pikachu: ~1.39.0
         raichu: 1.37.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart
       landscapes:
-        pichu: ^1.47.0
-        pikachu: ~1.47.0
+        pichu: ^1.48.0
+        pikachu: ~1.48.0
         raichu: 1.46.0
     helium:
       repoURL: ghcr.io/atomicloud/nitroso.helium


### PR DESCRIPTION
zinc 1.39.0 (AtomiCloud/nitroso.zinc#24), tin 1.48.0 (AtomiCloud/nitroso.tin#37) on pichu/pikachu. raichu untouched.