### PR TITLE
action: zinc to 1.40.0 on pichu and pikachu

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -11,8 +11,8 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.zinc
       chart: root-chart
       landscapes:
-        pichu: ^1.39.0
-        pikachu: ~1.39.0
+        pichu: ^1.40.0
+        pikachu: ~1.40.0
         raichu: 1.37.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin


### PR DESCRIPTION
Booking instant sorts (BuyTime/FulfilTime) + passenger userId exposure (AtomiCloud/nitroso.zinc#25). raichu untouched.