### PR TITLE
action: disable raichu withdrawer until Airwallex payouts are enabled

### DIFF
--- a/values/nitroso/tin/values.raichu.yaml
+++ b/values/nitroso/tin/values.raichu.yaml
@@ -22,3 +22,9 @@ buyer:
       sleepBuffer: 1
     stream:
       reserver: buyqueue
+
+# withdrawer parked until Airwallex PayNow payouts (Beta) are enabled on the
+# account: the nightly approve sweep would only bounce every Pending
+# withdrawal off the gateway. Re-enable by deleting this block.
+withdrawer:
+  enabled: false


### PR DESCRIPTION
Parks the tin withdrawer module (nightly Pending approve sweep + 6-hourly Processing reconcile sweep) on **raichu only** via the per-landscape override, until the Airwallex PayNow Beta is enabled. pikachu keeps it running for testing. Manual/admin withdrawal flows unaffected. Re-enable = delete the block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app settings to keep the withdrawal feature disabled for now.
  * Added guidance indicating the feature can be turned back on later by removing the added configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->