### PR TITLE
action: bump nitroso-zinc to 1.42.0 (fee queue v2)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -11,9 +11,9 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.zinc
       chart: root-chart
       landscapes:
-        pichu: ^1.41.0
-        pikachu: ~1.41.0
-        raichu: 1.41.0
+        pichu: ^1.42.0
+        pikachu: ~1.42.0
+        raichu: 1.42.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart


### PR DESCRIPTION
Rolls nitroso-zinc 1.41.0 → 1.42.0 on all landscapes (pichu ^, pikachu ~, raichu exact).

v1.42.0 = fee queue v2: per-type (withdrawal + deposit) queue of fee-change events with flat+percentage, default 0,0 (config fallback removed), deposit-fee ledger, generalized announcement email with custom reasoning. Migration renames Fees.WithdrawFeePercentage → Percentage and fixes the Costs seed churn.

⚠️ After raichu syncs: the live 4% withdrawal fee stops applying until an admin queues a fee event from the new /fees admin page.