### PR TITLE
action: bump nitroso-zinc to 1.43.1, nitroso-tin to 1.49.0

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -11,16 +11,16 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.zinc
       chart: root-chart
       landscapes:
-        pichu: ^1.42.0
-        pikachu: ~1.42.0
-        raichu: 1.42.0
+        pichu: ^1.43.1
+        pikachu: ~1.43.1
+        raichu: 1.43.1
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart
       landscapes:
-        pichu: ^1.48.0
-        pikachu: ~1.48.0
-        raichu: 1.48.0
+        pichu: ^1.49.0
+        pikachu: ~1.49.0
+        raichu: 1.49.0
     helium:
       repoURL: ghcr.io/atomicloud/nitroso.helium
       chart: root-chart


### PR DESCRIPTION
All landscapes (pichu ^, pikachu ~, raichu exact).

- **zinc 1.43.1**: booking queue position, search totals for real pagination, admin stats endpoint (day-of-week × time × direction × lead-time buckets), fuzzy passenger-name search, SGT dates in all user emails, ticket-upload verify-on-write + resilient link enrichment (#28, #29)
- **tin 1.49.0**: print-ticket CLI to re-download a ticket PDF from KTMB (#38)

Withdrawer stays disabled on raichu (unchanged).