### PR TITLE
action: bump nitroso-zinc to 1.44.0 (cost policies + priority queue)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -11,9 +11,9 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.zinc
       chart: root-chart
       landscapes:
-        pichu: ^1.43.1
-        pikachu: ~1.43.1
-        raichu: 1.43.1
+        pichu: ^1.44.0
+        pikachu: ~1.44.0
+        raichu: 1.44.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart


### PR DESCRIPTION
All landscapes. v1.44.0 adds the cost policy engine (schedulable ±flat/±% rules by date/time/day-of-week/direction/lead-time, itemized summary) and the priority queue (fee-gated queue jump, allowlist + window gating, snapshot-refunding). Dormant until configured from the upcoming argon admin UI — no policies exist and priority defaults to nobody-eligible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version constraints for several application components to align with a newer release line, helping keep deployments current and compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->