### PR TITLE
action: bump nitroso-zinc to 1.45.0 (per-slot pricing, roles, termination fee)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -11,9 +11,9 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.zinc
       chart: root-chart
       landscapes:
-        pichu: ^1.44.0
-        pikachu: ~1.44.0
-        raichu: 1.44.0
+        pichu: ^1.45.0
+        pikachu: ~1.45.0
+        raichu: 1.45.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart


### PR DESCRIPTION
All landscapes. v1.45.0: batch per-slot pricing (Cost/summary/batch), discount slot-targeting, admin-managed ExtraRoles (pricing-only), FeeType.Termination + cap on all fee types — migration seeds a fixed 50% termination row for live parity, so terminate behavior is unchanged until an admin edits it on /fees.