### PR TITLE
action: bump nitroso-zinc to 1.46.0 (stats v2 + milestones)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -11,9 +11,9 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.zinc
       chart: root-chart
       landscapes:
-        pichu: ^1.45.0
-        pikachu: ~1.45.0
-        raichu: 1.45.0
+        pichu: ^1.46.0
+        pikachu: ~1.46.0
+        raichu: 1.46.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart


### PR DESCRIPTION
All landscapes. v1.46.0: booking_stats materialized view (priority/demand/delivery dims, refresh-on-read with advisory lock), milestone CRUD. Migration creates + populates the view.