### PR TITLE
action: bump nitroso-zinc to 1.47.0, nitroso-tin to 1.50.0 (recovery retries + ticket repair)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -11,15 +11,15 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.zinc
       chart: root-chart
       landscapes:
-        pichu: ^1.46.0
-        pikachu: ~1.46.0
+        pichu: ^1.47.0
+        pikachu: ~1.47.0
         raichu: 1.46.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart
       landscapes:
-        pichu: ^1.49.0
-        pikachu: ~1.49.0
+        pichu: ^1.50.0
+        pikachu: ~1.50.0
         raichu: 1.49.0
     helium:
       repoURL: ghcr.io/atomicloud/nitroso.helium


### PR DESCRIPTION
Bumps pichu + pikachu pins; raichu untouched.

- **zinc 1.47.0** (nitroso.zinc#35): `recover-revert` endpoint (Recovering → Pending recycle, persisted RecoveryRetries counter, cap 10 via `Recovery:MaxRetries`), `Booking/ticket/{id}` repair endpoint, `ticket-health` probe, `MissingTicket` search filter. Migration adds RecoveryRetries (default 0) — backward compatible.
- **tin 1.50.0** (nitroso.tin#39): recoverer recycles duplicates via recover-revert (marks Duplicate only on 409 cap-exhausted or true already-claimed), plus missing-ticket repair sweep (KTMB re-download → upload).

Order-safe: zinc deploys with the same ArgoCD sync; tin against old zinc would just requeue (404 → transient), and old tin against new zinc is unchanged behavior.