### PR TITLE
action: raichu to zinc 1.47.0 + tin 1.50.1 (recovery retries, ticket repair, SG cutoff)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -13,14 +13,14 @@ apps:
       landscapes:
         pichu: ^1.47.0
         pikachu: ~1.47.0
-        raichu: 1.46.0
+        raichu: 1.47.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart
       landscapes:
         pichu: ^1.50.0
         pikachu: ~1.50.0
-        raichu: 1.49.0
+        raichu: 1.50.1
     helium:
       repoURL: ghcr.io/atomicloud/nitroso.helium
       chart: root-chart


### PR DESCRIPTION
Promotes raichu (prod) to the versions already verified on pichu + pikachu:

- **zinc 1.46.0 → 1.47.0**: Singapore purchase cutoff + optional canonical price quote (#34 — quote optional, so current raichu argon without quotes keeps working), recovery retries + ticket repair endpoints (#35). Migration adds RecoveryRetries (default 0) — backward compatible.
- **tin 1.49.0 → 1.50.1**: recoverer recycles duplicates via recover-revert up to zinc's cap of 10 before refunding (#39), missing-ticket repair sweep, semantic-status not-found classification (#40).

Both floop-reviewed (2 rounds, all lenses PASS) and running clean on pikachu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `raichu` version constraints for the `nitroso` application in the `zinc` and `tin` configurations.
  * No other chart or repository configuration was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->