### PR TITLE
action: pichu+pikachu to zinc 1.48.0 + tin 1.51.0 (card-refund withdrawals)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -11,15 +11,15 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.zinc
       chart: root-chart
       landscapes:
-        pichu: ^1.47.0
-        pikachu: ~1.47.0
+        pichu: ^1.48.0
+        pikachu: ~1.48.0
         raichu: 1.47.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart
       landscapes:
-        pichu: ^1.50.0
-        pikachu: ~1.50.0
+        pichu: ^1.51.0
+        pikachu: ~1.51.0
         raichu: 1.50.1
     helium:
       repoURL: ghcr.io/atomicloud/nitroso.helium


### PR DESCRIPTION
Bumps pichu + pikachu; **raichu untouched** (per deploy policy: user reviews pikachu first).

- **zinc 1.48.0** (nitroso.zinc#36): card-refund withdrawal rail — method on withdrawals (PayNow default for legacy rows), fragmented oldest-first-in-180d refunds via Airwallex refunds API, per-fragment evidence table exposed on the detail response, refundable-pool endpoint, refund.* webhook routing, 409 insufficient_refundable_pool, migration AddWithdrawalMethodAndRefundFragments.
- **tin 1.51.0** (nitroso.tin#42): withdrawer approveEnable gate, **default false** — auto-approve sweep off; reconcile sweep keeps running so in-flight payouts settle.