### PR TITLE
action: pichu+pikachu to zinc 1.50.0 + tin 1.52.0 (analysis, priority targeting, withdrawal policy)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -11,15 +11,15 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.zinc
       chart: root-chart
       landscapes:
-        pichu: ^1.48.0
-        pikachu: ~1.48.0
+        pichu: ^1.50.0
+        pikachu: ~1.50.0
         raichu: 1.47.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart
       landscapes:
-        pichu: ^1.51.0
-        pikachu: ~1.51.0
+        pichu: ^1.52.0
+        pikachu: ~1.52.0
         raichu: 1.50.1
     helium:
       repoURL: ghcr.io/atomicloud/nitroso.helium


### PR DESCRIPTION
Bumps pichu + pikachu; raichu untouched (deploy policy: user reviews pikachu first).

- **zinc 1.49.0→1.50.0** (#37 + #38): sales analysis endpoints (per-day tickets/direction/time + gross revenue + deposits + internal fees; captured-payments list), priority boost targeting (freeTarget/accessTarget in discount-target shape), withdrawal method policy (cardRefundEnabled, payNowMode Enabled/Disabled/FallbackOnly enforced at create, sweepEnabled runtime flag).
- **tin 1.52.0** (#43): runtime sweep gate — approve sweep runs only when config killswitch AND zinc's sweepEnabled are both on; fail-closed; reconcile untouched.