### PR TITLE
action: raichu to zinc 1.50.0 + tin 1.52.0 (card refunds, analysis, priority targeting, withdrawal policy)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -13,14 +13,14 @@ apps:
       landscapes:
         pichu: ^1.50.0
         pikachu: ~1.50.0
-        raichu: 1.47.0
+        raichu: 1.50.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart
       landscapes:
         pichu: ^1.52.0
         pikachu: ~1.52.0
-        raichu: 1.50.1
+        raichu: 1.52.0
     helium:
       repoURL: ghcr.io/atomicloud/nitroso.helium
       chart: root-chart


### PR DESCRIPTION
Promotes raichu (prod) to the versions verified on pikachu by the owner:

- **zinc 1.47.0 → 1.50.0**: card-refund withdrawal rail (#36), sales analysis endpoints + priority boost targeting (#37), withdrawal method policy + sweep flag (#38). Migrations: WithdrawalMethod+RefundFragments, PriorityTargets, WithdrawalSettings — all additive/backward compatible.
- **tin 1.50.1 → 1.52.0**: withdrawer approveEnable config gate (#42), runtime sweep gate from zinc settings — fail-closed, reconcile untouched (#43).

Server-side defaults keep behavior safe on rollout: card refund on, PayNow fallback-only, sweep OFF until enabled from the admin UI.