### PR TITLE
action: pichu+pikachu to zinc 1.51.0 (airwallex fees, ktmb costs, boost audit, queue split)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -11,8 +11,8 @@ apps:
       repoURL: ghcr.io/atomicloud/nitroso.zinc
       chart: root-chart
       landscapes:
-        pichu: ^1.50.0
-        pikachu: ~1.50.0
+        pichu: ^1.51.0
+        pikachu: ~1.51.0
         raichu: 1.50.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin


### PR DESCRIPTION
Bumps pichu + pikachu; raichu untouched (deploy policy: user reviews pikachu first).

**zinc 1.51.0** (nitroso.zinc#39): Airwallex financial-transactions fee capture (GatewayFees table + sync endpoint + monthly P&L aggregation with net = gross − ktmb − gateway fees), KTMB cost settings (effective-dated per direction), price-breakdown persistence at purchase (components analytics), boost audit (PrioritizedAt/PrioritizedBy), booking counts split priority/normal. All migrations additive.