### PR TITLE
action: raichu to zinc 1.52.0 (boost-time priority queue ordering)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -13,7 +13,7 @@ apps:
       landscapes:
         pichu: ^1.51.0
         pikachu: ~1.51.0
-        raichu: 1.50.0
+        raichu: 1.52.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart


### PR DESCRIPTION
Bumps raichu's nitroso/zinc pin `1.50.0 → 1.52.0`.

- **1.52.0**: priority group now ordered by boost time (`PrioritizedAt`, NULL falls back to `CreatedAt` so pre-audit boosts keep their position) — https://github.com/AtomiCloud/nitroso.zinc/pull/40
- also picks up **1.51.0** (airwallex fee capture, ktmb costs, boost audit, queue split), already live on pichu/pikachu