### PR TITLE
action: raichu to zinc 1.53.0 (queue priority/normal split)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -13,7 +13,7 @@ apps:
       landscapes:
         pichu: ^1.51.0
         pikachu: ~1.51.0
-        raichu: 1.52.0
+        raichu: 1.53.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart


### PR DESCRIPTION
Bumps raichu's nitroso/zinc pin `1.52.0 → 1.53.0`: queue position endpoint now returns the priority/normal composition of the timeslot's queue — https://github.com/AtomiCloud/nitroso.zinc/pull/41. Additive API change, no migration.