### PR TITLE
action: pikachu to zinc ~1.53.0 (queue priority/normal split)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -12,7 +12,7 @@ apps:
       chart: root-chart
       landscapes:
         pichu: ^1.51.0
-        pikachu: ~1.51.0
+        pikachu: ~1.53.0
         raichu: 1.53.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin


### PR DESCRIPTION
Bumps pikachu's nitroso/zinc pin `~1.51.0 → ~1.53.0` so the queue-split frontend (argon) has the `priorityTotal`/`normalTotal` fields on pikachu. Raichu already runs 1.53.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the platform configuration to support the latest compatible application release.
  * No other configuration or user-facing behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->