### PR TITLE
action: pikachu to zinc ~1.54.0 (priority policies and slot cap)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -12,7 +12,7 @@ apps:
       chart: root-chart
       landscapes:
         pichu: ^1.51.0
-        pikachu: ~1.53.0
+        pikachu: ~1.54.0
         raichu: 1.53.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin


### PR DESCRIPTION
Bumps pikachu's nitroso/zinc pin `~1.53.0 → ~1.54.0`: priority policy chain (hours-to-departure + role targeting) and per-timeslot slot cap — https://github.com/AtomiCloud/nitroso.zinc/pull/42. Migration is additive (Policies jsonb + SlotCap). Raichu stays pinned at 1.53.0.