### PR TITLE
action: pikachu to zinc ~1.55.0 (unified priority policy chain)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -12,7 +12,7 @@ apps:
       chart: root-chart
       landscapes:
         pichu: ^1.51.0
-        pikachu: ~1.54.0
+        pikachu: ~1.55.0
         raichu: 1.53.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin


### PR DESCRIPTION
Bumps pikachu nitroso/zinc ~1.54.0 -> ~1.55.0: the priority queue is now one unified policy chain — https://github.com/AtomiCloud/nitroso.zinc/pull/43. Raichu untouched.