### PR TITLE
action: raichu to zinc 1.55.0 (unified priority policy chain)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -13,7 +13,7 @@ apps:
       landscapes:
         pichu: ^1.51.0
         pikachu: ~1.55.0
-        raichu: 1.53.0
+        raichu: 1.55.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart


### PR DESCRIPTION
Promotes raichu nitroso/zinc 1.53.0 -> 1.55.0: unified priority policy chain + per-timeslot slot caps (https://github.com/AtomiCloud/nitroso.zinc/pull/43). Legacy settings synthesize server-side; behavior unchanged until an admin saves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Nitroso Zinc app’s Raichu landscape version from 1.53.0 to 1.55.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->