### PR TITLE
action: raichu to zinc 1.55.1 (slot-aware purchase boost eligibility)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -13,7 +13,7 @@ apps:
       landscapes:
         pichu: ^1.51.0
         pikachu: ~1.55.0
-        raichu: 1.55.0
+        raichu: 1.55.1
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart


### PR DESCRIPTION
Bumps the raichu exact pin `1.55.0 → 1.55.1` under `apps.nitroso.zinc.landscapes`.

zinc v1.55.1 (AtomiCloud/nitroso.zinc#44) makes the generic priority-eligibility endpoint slot-aware, fixing the purchase page hiding the boost opt-in for everyone when the default policy is hour-bounded. pikachu's `~1.55.0` range picks the patch automatically — no change needed there. No new migration in this release.

https://claude.ai/code/session_018kJbfRkYZXikAELSDPj7pX