### PR TITLE
action: pikachu/raichu to zinc 1.56.0 + tin 1.53.0 (KTMB actual-cost capture)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -12,15 +12,15 @@ apps:
       chart: root-chart
       landscapes:
         pichu: ^1.51.0
-        pikachu: ~1.55.0
-        raichu: 1.55.1
+        pikachu: ~1.56.0
+        raichu: 1.56.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart
       landscapes:
         pichu: ^1.52.0
-        pikachu: ~1.52.0
-        raichu: 1.52.0
+        pikachu: ~1.53.0
+        raichu: 1.53.0
     helium:
       repoURL: ghcr.io/atomicloud/nitroso.helium
       chart: root-chart


### PR DESCRIPTION
Rolls out the KTMB actual-cost feature train:

- **zinc 1.56.0** (AtomiCloud/nitroso.zinc#45): actual KTMB cost on booking completion, backfill + worklist endpoints, MYR→SGD effective-dated FX rates, analysis uses actual cost with coverage. Includes migration `AddKtmbActualCostAndFxRates` (additive: 2 nullable columns + new table).
- **tin 1.53.0** (AtomiCloud/nitroso.tin#44): buyer reports the paid amount/currency on completion; new `ktmb-cost-backfill` command.

Both are minors — pikachu tilde ranges bumped alongside the raichu exact pins. pichu carets pick them automatically.

https://claude.ai/code/session_018kJbfRkYZXikAELSDPj7pX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application versions for the zinc landscape to 1.56.0.
  * Updated application versions for the tin landscape to 1.53.0.
  * Preserved existing version constraints for the pichu landscape.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->