### PR TITLE
action: pikachu/raichu to zinc 1.57.0 (travel-date demand analysis)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -12,8 +12,8 @@ apps:
       chart: root-chart
       landscapes:
         pichu: ^1.51.0
-        pikachu: ~1.56.0
-        raichu: 1.56.0
+        pikachu: ~1.57.0
+        raichu: 1.57.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart


### PR DESCRIPTION
zinc 1.57.0 (AtomiCloud/nitroso.zinc#46) adds GET Booking/analysis/travel — completed tickets grouped by TRAVEL date × 6h quarter buckets, powering the new 'Secured by travel date' section on argon's /stats (AtomiCloud/nitroso.argon#284). Minor release → pikachu tilde range bumped with the raichu pin.

https://claude.ai/code/session_018kJbfRkYZXikAELSDPj7pX