### PR TITLE
action: raichu to tin 1.53.1 (KTMB backfill session refresh)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -20,7 +20,7 @@ apps:
       landscapes:
         pichu: ^1.52.0
         pikachu: ~1.53.0
-        raichu: 1.53.0
+        raichu: 1.53.1
     helium:
       repoURL: ghcr.io/atomicloud/nitroso.helium
       chart: root-chart


### PR DESCRIPTION
Bumps raichu tin exact pin 1.53.0 → 1.53.1 (pikachu ~1.53.0 picks the patch automatically).

v1.53.1 = nitroso.tin#45: the ktmb-cost-backfill command now recognizes KTMB's invalid-session rejection, atomically invalidates the stale cached login token, re-logs-in and retries once — fixing the dry-run where all GetTicket calls failed with 'Please login to continue.'

https://claude.ai/code/session_018kJbfRkYZXikAELSDPj7pX