### PR TITLE
action: pikachu/raichu to zinc 1.58.0 (travel-day profit analysis)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -12,8 +12,8 @@ apps:
       chart: root-chart
       landscapes:
         pichu: ^1.51.0
-        pikachu: ~1.57.0
-        raichu: 1.57.0
+        pikachu: ~1.58.0
+        raichu: 1.58.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart


### PR DESCRIPTION
Bumps zinc pikachu ~1.57.0 → ~1.58.0 and raichu 1.57.0 → 1.58.0.

v1.58.0 = nitroso.zinc#47: GET /Booking/analysis/profit (per-travel-day 6h-block tickets/revenue/actual-cost rows) and the booking analysis estimate fallback becomes opt-in (Estimate=true) — default cost now counts only actual KTMB amounts.

https://claude.ai/code/session_018kJbfRkYZXikAELSDPj7pX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform components to the latest 1.58 release line.
  * Improved consistency between component version configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->