### PR TITLE
action: pikachu/raichu to zinc 1.59.1 (P&L endpoint + gateway fee auto-sync)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -12,8 +12,8 @@ apps:
       chart: root-chart
       landscapes:
         pichu: ^1.51.0
-        pikachu: ~1.58.0
-        raichu: 1.58.0
+        pikachu: ~1.59.0
+        raichu: 1.59.1
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart


### PR DESCRIPTION
zinc 1.58.0 → 1.59.1: #48 monthly P&L analysis endpoint; #49 payment gateway-fee sync fixed (attempt-id) + hourly auto-sync worker (backfills all Airwallex fee history on first run).

https://claude.ai/code/session_018kJbfRkYZXikAELSDPj7pX