### PR TITLE
action: pikachu/raichu to zinc 1.61.0 + tin 1.54.0 (partner economics, KTMB refund capture)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -12,15 +12,15 @@ apps:
       chart: root-chart
       landscapes:
         pichu: ^1.51.0
-        pikachu: ~1.59.0
-        raichu: 1.59.1
+        pikachu: ~1.61.0
+        raichu: 1.61.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart
       landscapes:
         pichu: ^1.52.0
-        pikachu: ~1.53.0
-        raichu: 1.53.1
+        pikachu: ~1.54.0
+        raichu: 1.54.0
     helium:
       repoURL: ghcr.io/atomicloud/nitroso.helium
       chart: root-chart


### PR DESCRIPTION
zinc 1.59.1 → 1.61.0: #50 partner listing + per-user P&L; #51 KTMB termination refund capture (migration adds Bookings.KtmbRefundAmount/Currency; termination queue payload gains booking id).
tin 1.53.1 → 1.54.0: #46 terminator posts exact KTMB refunds; ktmb-cost-backfill gains --status and --refund modes.

https://claude.ai/code/session_018kJbfRkYZXikAELSDPj7pX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version constraints for zinc landscapes to the 1.61 release.
  * Updated application version constraints for tin landscapes to the 1.54 release.
  * Retained the existing pichu version constraint for tin landscapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->