### PR TITLE
action: raichu to zinc 1.61.1 (terminated-booking cost recording)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -13,7 +13,7 @@ apps:
       landscapes:
         pichu: ^1.51.0
         pikachu: ~1.61.0
-        raichu: 1.61.0
+        raichu: 1.61.1
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart


### PR DESCRIPTION
zinc #52: POST Booking/{id}/ktmb-cost now accepts Terminated bookings (the worklist already served them) — unblocks the 655-booking terminated cost backfill. pikachu ~1.61.0 picks the patch automatically.

https://claude.ai/code/session_018kJbfRkYZXikAELSDPj7pX