### PR TITLE
action: pikachu/raichu to zinc 1.63.0 (boost counts, account fees, owner gate)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -12,8 +12,8 @@ apps:
       chart: root-chart
       landscapes:
         pichu: ^1.51.0
-        pikachu: ~1.62.0
-        raichu: 1.62.0
+        pikachu: ~1.63.0
+        raichu: 1.63.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart


### PR DESCRIPTION
zinc #54: partner boost counts on /User/{id}/pnl; Airwallex account-level FEE sweep (747 batches, −S$2,575.91 backfill) attributed into gwRate; owner-only history clamp (non-owner admins see June 2026+).

https://claude.ai/code/session_018kJbfRkYZXikAELSDPj7pX