### PR TITLE
action: raichu to zinc 1.64.1 + tin 1.54.1 (frontier review fixes)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -13,14 +13,14 @@ apps:
       landscapes:
         pichu: ^1.51.0
         pikachu: ~1.64.0
-        raichu: 1.64.0
+        raichu: 1.64.1
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart
       landscapes:
         pichu: ^1.52.0
         pikachu: ~1.54.0
-        raichu: 1.54.0
+        raichu: 1.54.1
     helium:
       repoURL: ghcr.io/atomicloud/nitroso.helium
       chart: root-chart


### PR DESCRIPTION
Review fixes from the sol-5.6 adversarial pass: zinc #56 (extreme SGT range bounds 500) and tin #47 (HIGH: terminator could refund the wrong ticket on multi-ticket bookings; refund-amount fallback misattribution). pikachu ~ranges pick the patches automatically.

https://claude.ai/code/session_018kJbfRkYZXikAELSDPj7pX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the nitroso application components to newer patch versions for improved maintenance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->