### PR TITLE
action: raichu to zinc 1.64.2 (partner consumption + owner gate)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -13,7 +13,7 @@ apps:
       landscapes:
         pichu: ^1.51.0
         pikachu: ~1.64.0
-        raichu: 1.64.1
+        raichu: 1.64.2
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart


### PR DESCRIPTION
zinc #57: boostCount includes free boosts, distinctPassengers reselling signal, /User/partners + /User/{id}/pnl owner-only.

https://claude.ai/code/session_018kJbfRkYZXikAELSDPj7pX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Raichu application to version 1.64.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->