### PR TITLE
action: pikachu tin ~1.55.0 + epoch prober DRY-RUN

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -19,7 +19,7 @@ apps:
       chart: root-chart
       landscapes:
         pichu: ^1.52.0
-        pikachu: ~1.54.0
+        pikachu: ~1.55.0
         raichu: 1.54.1
     helium:
       repoURL: ghcr.io/atomicloud/nitroso.helium

--- a/values/nitroso/tin/values.pikachu.yaml
+++ b/values/nitroso/tin/values.pikachu.yaml
@@ -8,3 +8,20 @@ poller:
     poller:
       pollee:
         version: '1.19.0'
+# --- epoch prober DRY-RUN validation (Phase 0, EPOCH-PROBER.md §9) ---
+# spawner ticks every minute and spawns tin-prober-<epoch>-<shard>-<fanout>
+# Jobs that probe KTMB Reserve on the enricher account, log polls/holds
+# tallies, and CANCEL every hold immediately (dryRun) — no ReserveDto is
+# enqueued, no money moves. The legacy reserver/buyer are scaled to 0 for
+# the money-leak isolation the PR #41 review demanded (a cancelled hold
+# re-appearing as availability must not trigger a legacy buy).
+# REVERT = spawner.enabled false + restore reserver/buyer replicas.
+spawner:
+  enabled: true
+  appSettings:
+    prober:
+      dryRun: true
+reserver:
+  replicaCount: 0
+buyer:
+  replicaCount: 0


### PR DESCRIPTION
Phase 0 validation of the epoch prober (tin #41) on pikachu ONLY:
- pikachu tin range ~1.54.0 → ~1.55.0 (v1.55.0 = the prober; raichu stays pinned 1.54.1 — untouched)
- spawner.enabled=true with prober.dryRun=true: probes real KTMB Reserve on the enricher account, tallies polls/holds, cancels every hold, enqueues nothing — zero money movement
- reserver+buyer scaled to 0 on pikachu for cross-pipeline isolation (review blocker #1: a cancelled hold must not re-trigger a legacy buy)
Revert = flip spawner.enabled false + restore replicas.

https://claude.ai/code/session_018kJbfRkYZXikAELSDPj7pX