### PR TITLE
action: pikachu prober 1 CPU/1Gi (scaling test) + tin ~1.56.0

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -19,7 +19,7 @@ apps:
       chart: root-chart
       landscapes:
         pichu: ^1.52.0
-        pikachu: ~1.55.0
+        pikachu: ~1.56.0
         raichu: 1.54.1
     helium:
       repoURL: ghcr.io/atomicloud/nitroso.helium

--- a/values/nitroso/tin/values.pikachu.yaml
+++ b/values/nitroso/tin/values.pikachu.yaml
@@ -16,11 +16,25 @@ poller:
 # the money-leak isolation the PR #41 review demanded (a cancelled hold
 # re-appearing as availability must not trigger a legacy buy).
 # REVERT = spawner.enabled false + restore reserver/buyer replicas.
+#
+# SCALING TEST (was 250m/128Mi): both the spawner (which does enrichment)
+# and the spawned prober Jobs bumped to 1 CPU / 1Gi, requests==limits
+# (Guaranteed QoS, integer CPU => CPU-pinning-eligible; true core-pinning
+# still needs the node kubelet cpu-manager-policy=static, currently 'none').
 spawner:
   enabled: true
+  resources:
+    requests:
+      cpu: '1'
+      memory: '1Gi'
+    limits:
+      cpu: '1'
+      memory: '1Gi'
   appSettings:
     prober:
       dryRun: true
+      jobCpu: '1'
+      jobMemory: '1Gi'
 reserver:
   replicaCount: 0
 buyer:


### PR DESCRIPTION
Bumps the pikachu prober Job + spawner from 250m/128Mi to 1 CPU / 1Gi (requests==limits, Guaranteed QoS) to find the true single-pod throughput ceiling. Needs tin ~1.56.0 (PR #50 = configurable prober Job resources). pikachu only; raichu untouched.

Revert = spawner.enabled false + restore reserver/buyer replicas.

https://claude.ai/code/session_018kJbfRkYZXikAELSDPj7pX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit CPU and memory sizing for epoch-prober dry-run jobs.
  * Added scaling-test guidance and configuration details for the prober setup.

* **Chores**
  * Updated the Pikachu version constraint to the 1.56 release line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->