### PR TITLE
feat(pikachu/tin): switch enricher account to ernest@bunnybooker.com

### DIFF
--- a/values/nitroso/tin/values.pikachu.yaml
+++ b/values/nitroso/tin/values.pikachu.yaml
@@ -1,7 +1,7 @@
 enricher:
   appSettings:
     enricher:
-      email: ramadan@quantumquokkaquest.cfd
+      email: ernest@bunnybooker.com
 poller:
   replicaCount: 0
   appSettings:


### PR DESCRIPTION
## What
Pin the **pikachu** tin enricher/prober account to **ernest@bunnybooker.com** (a real, funded KTMB account), replacing the throwaway `ramadan@quantumquokkaquest.cfd`.

## Why
The epoch-prober scaling test on pikachu needs to run against a **real account + money** (real KTMB Reserve holds), which requires a funded account. ramadan can't back real reservations.

## Safety / verification
- Password delivered separately via **Infisical** (`ATOMI_ENRICHER__PASSWORD`, project `nitroso-tin` / env `pikachu`) — not in this diff.
- **Login verified**: after ernest was logged out of its prior external session, a fresh login succeeded with **no "multiple login" error**, and a valid session token (2833 bytes, no TTL) was written to Upstash.
- Scope is **pikachu only**. raichu (`kirinnee97@gmail.com`) is untouched.
- **Revert** = restore `email: ramadan@quantumquokkaquest.cfd`.

## Merge unblocks
Once merged + argocd-synced, the enricher runs as ernest durably, and the full 500-slot scaling experiment can run without argocd reverting the account mid-run.

https://claude.ai/code/session_013xKVMwy1C4nj7UDuMXpJEA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Updated the enricher email configuration to use the new contact address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->