### PR TITLE
action: pikachu to zinc 1.65.0 (trim passenger names + forgiving cancel)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -12,7 +12,7 @@ apps:
       chart: root-chart
       landscapes:
         pichu: ^1.51.0
-        pikachu: ~1.64.0
+        pikachu: ~1.65.0
         raichu: 1.64.2
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin


### PR DESCRIPTION
Promotes **nitroso.zinc** to `~1.65.0` on the **pikachu** landscape (raichu unchanged at 1.64.2).

Lands the backend half of the passenger name/passport fix on pikachu:
- Trim name + passport on every write path (normalized before validation)
- Migration cleaning existing `Passengers` + booking-snapshot rows

Pairs with argon (already merged to `pikachu`) and zinc v1.65.0 (merged to `main`).

https://claude.ai/code/session_01XDtmdmD8g5HDY1kEDH3i8b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version constraint to the 1.65 release line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->