### PR TITLE
action: raichu to zinc 1.65.0 (trim passenger names + forgiving cancel)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -13,7 +13,7 @@ apps:
       landscapes:
         pichu: ^1.51.0
         pikachu: ~1.65.0
-        raichu: 1.64.2
+        raichu: 1.65.0
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart


### PR DESCRIPTION
Promotes **nitroso.zinc** to `1.65.0` on the **raichu (prod)** landscape. Already live on pikachu.

Lands the backend fix in prod:
- Trim name + passport on every write path (normalized before validation)
- Migration cleaning existing `Passengers` + booking-snapshot rows (collision-safe, only touches changed rows)

Pairs with argon pikachu→raichu promotion (nitroso.argon #337).

https://claude.ai/code/session_01XDtmdmD8g5HDY1kEDH3i8b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployed application version to 1.65.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->