### PR TITLE
action: raichu to zinc 1.65.1 (payment status-history mapping fix)

### DIFF
--- a/chart/values.entei.opal-ruby.yaml
+++ b/chart/values.entei.opal-ruby.yaml
@@ -13,7 +13,7 @@ apps:
       landscapes:
         pichu: ^1.51.0
         pikachu: ~1.65.0
-        raichu: 1.65.0
+        raichu: 1.65.1
     tin:
       repoURL: ghcr.io/atomicloud/nitroso.tin
       chart: root-chart


### PR DESCRIPTION
## Summary

Points raichu at zinc **1.65.1** (nitroso.zinc#59): `PaymentMapper.ToPrincipal` no longer throws on repeated statuses in the payment history (3DS retry loops) — this was 500ing the admin per-user payment search AND every Airwallex webhook update for affected payments on raichu.

pichu (`^1.51.0`) and pikachu (`~1.65.0`) pick 1.65.1 up automatically; only the exact raichu pin needed the bump.

https://claude.ai/code/session_01XDtmdmD8g5HDY1kEDH3i8b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Raichu application to version 1.65.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->